### PR TITLE
air75v2: mcu_pwr: Move the led wake up after clock init

### DIFF
--- a/keyboards/nuphy/air75v2/ansi/mcu_pwr.c
+++ b/keyboards/nuphy/air75v2/ansi/mcu_pwr.c
@@ -187,10 +187,10 @@ void exit_deep_sleep(void) {
     gpio_write_pin_high(NRF_WAKEUP_PIN);
 #endif
 
-    led_pwr_wake_handle();
-
     // 重新初始化系统时钟
     stm32_clock_init();
+
+    led_pwr_wake_handle();
 
     /* TIM6 使能 */
     if (tim6_enabled) TIM_Cmd(TIM6, ENABLE);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This change fixes the quick white lights flash happening right after the keyboard wakes up from deep sleep mode while in wireless mode

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #1 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
